### PR TITLE
Symbol overrides should be nested directly

### DIFF
--- a/types.js
+++ b/types.js
@@ -231,9 +231,7 @@ export type SJSymbolInstanceLayer = {
   masterInfluenceEdgeMaxYPadding?: number,
   symbolID: SJObjectId,
   overrides?: {
-    '0': {
-      [objectId: SJObjectId]: string | SJNestedSymbolOverride | SJImageDataReference,
-    },
+    [objectId: SJObjectId]: string | SJNestedSymbolOverride | SJImageDataReference,
   },
 } & _SJLayerBase;
 


### PR DESCRIPTION
The original code worked correctly in v43, but stopped sometime later.

This code still supports v43.